### PR TITLE
docs: outline interactive session browser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@
 - Session JSONL fixtures live outside the repo; the tool reads from `~/.codex/sessions` or a user-supplied directory at runtime.
 
 ## Build, Test, and Development Commands
-- Install editable locally for rapid iteration: `python -m pip install -e .` (or `pipx install --editable . --force` when refreshing an existing pipx venv).
+- Install locally from the repo (no PyPI package yet):
+  - Users: `python -m pip install .` or include the interactive extra with `python -m pip install .[browser]`.
+  - Developers: `python -m pip install -e .[browser]` for editable work, or `pipx install --editable .` followed by `pipx inject codex-summarize-session prompt_toolkit`.
 - Run the CLI without installing: `python -m codex_summarize_session.cli list` or add extra args (`extract`, `--sessions-dir`, etc.).
-- No dedicated test suite yet; prefer manual smoke runs of `list` and `extract` after changes.
+- No dedicated test suite yet; prefer manual smoke runs of `list`, `extract`, and `browse` after changes.
+- After switching between pip/pipx installs, run `hash -r` so Bash refreshes cached command paths before re-testing.
 
 ## Coding Style & Naming Conventions
 - Python 3.8+ code; follow PEP 8 with 4-space indentation and descriptive, lowercase variable names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 while it remains under the `0.x` line (breaking changes may still occur).
 
 ## [Unreleased]
+### Added
+- Optional `[browser]` extra that provides `prompt_toolkit` support for the new interactive session browser.
+- `codex-summarize-session browse` command with arrow-key navigation and in-place message extraction.
 
+### Documentation
+- Describe the interactive browser workflow and optional dependency in `README.md`.
 
 ## [0.2.0] - 2024-09-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Features
 - Default output path is the current working directory (not the script location).
 - Accept either a full path or just the filename present under the sessions dir.
 - Jump straight from `list` to `extract` by passing the numeric row shown in the listing.
+- Optional interactive browser (`browse` subcommand) with arrow-key navigation.
 
 Install
 -------
@@ -25,6 +26,11 @@ Install
    - **pip (inside a venv or with `--user`)**
      - `python3 -m pip install --user .`
      - Installs into the active environment. Use `--user` or an activated virtualenv to avoid needing `sudo` and to prevent dependency conflicts.
+
+3. Want the interactive browser? Install the optional extra that pulls in `prompt_toolkit`:
+   - PyPI/package install: `python -m pip install codex-summarize-session[browser]`
+   - From a local checkout: `python -m pip install .[browser]`
+   - pipx users can inject the dependency after installing the CLI: `pipx inject codex-summarize-session prompt_toolkit`
 
 Either option installs the `codex-summarize-session` executable to a bin directory on your PATH (commonly `~/.local/bin`).
 
@@ -49,6 +55,11 @@ Usage
 
   - `codex-summarize-session list`
   - `codex-summarize-session list --limit 50`
+
+- Browse interactively (requires the optional `[browser]` extra):
+
+  - `codex-summarize-session browse`
+  - `codex-summarize-session browse --limit 50`
 
 - Extract by filepath:
 
@@ -87,3 +98,9 @@ Notes
 - Malformed JSON lines are skipped instead of aborting the extraction.
 - A future `summarize` command can be added to call an LLM API or a local model.
 - Extraction normalizes entries where messages are wrapped in `response_item` payloads and preserves timestamps when present.
+- The `browse` command will prompt for a destination path (pre-filled with a sensible default). Press `Ctrl+C` to cancel.
+- When `prompt_toolkit` is missing, the CLI suggests installing the optional `[browser]` extra before launching the interactive mode.
+
+Development Notes
+-----------------
+- Test both dependency setups when iterating on the browser: run once with `prompt_toolkit` installed (`python -m pip install .[browser]` or `pipx inject codex-summarize-session prompt_toolkit`) and again after uninstalling it (`python -m pip uninstall prompt_toolkit`) to ensure the CLI’s guidance for missing extras stays accurate.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ There is no PyPI package yet—install directly from this repository.
 2. `cd codex-summarize-session`
 3. Pick your install style:
    - **pip (current environment)**
-     - Standard CLI: `python -m pip install .`
-     - With interactive browser: `python -m pip install .[browser]`
-     - Editable: add `-e`, e.g. `python -m pip install -e .[browser]`
+     - Standard CLI: `pip install .`
+     - With interactive browser: `pip install .[browser]`
+     - Editable: add `-e`, e.g. `pip install -e .[browser]`
    - **pipx (isolated venv)**
      - Standard CLI: `pipx install .`
      - With interactive browser: `pipx install .[browser]`
@@ -44,6 +44,9 @@ Uninstall
 
 Iterate Without Reinstalling
 ----------------------------
+- Editable installation
+  - `pip install -e .[browser]`
+  - `pipx install --editable .[browser]`
 - Run directly without install:
   - `python codex_summarize_session/cli.py list`
   - `python -m codex_summarize_session.cli extract <session.jsonl>`

--- a/README.md
+++ b/README.md
@@ -18,35 +18,35 @@ Features
 
 Install
 -------
-1. Ensure Python 3.8+ is available.
-2. Pick the installation style that fits your workflow:
-   - **pipx (recommended for CLIs)**
-     - `pipx install .`
-     - Keeps each CLI in its own isolated virtual environment, exposes the command on your PATH, and makes uninstalling low-risk.
-   - **pip (inside a venv or with `--user`)**
-     - `python3 -m pip install --user .`
-     - Installs into the active environment. Use `--user` or an activated virtualenv to avoid needing `sudo` and to prevent dependency conflicts.
+There is no PyPI package yet—install directly from this repository.
 
-3. Want the interactive browser? Install the optional extra that pulls in `prompt_toolkit`:
-   - PyPI/package install: `python -m pip install codex-summarize-session[browser]`
-   - From a local checkout: `python -m pip install .[browser]`
-   - pipx users can inject the dependency after installing the CLI: `pipx inject codex-summarize-session prompt_toolkit`
+### Install from this repo
+1. `git clone git@github.com:QLiMBer/codex-summarize-session.git`
+2. `cd codex-summarize-session`
+3. Pick your install style:
+   - **pip (current environment)**
+     - Standard CLI: `python -m pip install .`
+     - With interactive browser: `python -m pip install .[browser]`
+     - Editable: add `-e`, e.g. `python -m pip install -e .[browser]`
+   - **pipx (isolated venv)**
+     - Standard CLI: `pipx install .`
+     - With interactive browser: `pipx install .[browser]`
+     - Editable: `pipx install --editable .[browser]` (use `--force` when refreshing an existing install)
 
-Either option installs the `codex-summarize-session` executable to a bin directory on your PATH (commonly `~/.local/bin`).
+Either approach drops the `codex-summarize-session` entrypoint on your PATH (often `~/.local/bin` or the active virtualenv).
 
 Uninstall
 ---------
 - pipx: `pipx uninstall codex-summarize-session`
 - pip: `pip uninstall codex-summarize-session`
+  - prompt_toolkit: it is not automatically uninstalled
+  - you can manually uninstall it using `pip uninstall prompt_toolkit`
 
 Iterate Without Reinstalling
 ----------------------------
 - Run directly without install:
   - `python codex_summarize_session/cli.py list`
   - `python -m codex_summarize_session.cli extract <session.jsonl>`
-- Editable/dev install (picks up code changes):
-  - pipx: `pipx install --editable . --force` (use `--force` when you need to refresh an existing pipx venv)
-  - pip in a venv: `python -m venv .venv && source .venv/bin/activate && pip install -e .`
 - Ad-hoc run (no permanent install): `pipx run --spec . codex-summarize-session list`
 
 Usage
@@ -104,3 +104,5 @@ Notes
 Development Notes
 -----------------
 - Test both dependency setups when iterating on the browser: run once with `prompt_toolkit` installed (`python -m pip install .[browser]` or `pipx inject codex-summarize-session prompt_toolkit`) and again after uninstalling it (`python -m pip uninstall prompt_toolkit`) to ensure the CLI’s guidance for missing extras stays accurate.
+- If you keep both a pip and pipx install, whichever `codex-summarize-session` appears first on `PATH` wins. Run `which codex-summarize-session` to confirm, or uninstall one copy before testing changes.
+- After changing installs, run `hash -r` (or open a new shell) so Bash forgets cached command locations; otherwise it might still call a removed shim.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,10 @@
   - keyboard shortcut / menu
 - Find (and summarize) the relevant previous sessions (based on cwd)?
 
+- Sessions filtering
+  - recent
+  - selected date span
+
 - Add automated tests covering message extraction, especially nested `response_item` payloads.
 
 
@@ -16,3 +20,7 @@
   - Prepare PyPI metadata (project description, classifiers) and generate an API token.
   - Rehearse on TestPyPI (`twine upload --repository testpypi dist/*`) before pushing to the main index.
   - After publishing, verify with `pip install codex-summarize-session==<version>` in a fresh environment.
+
+## Open Questions
+- Should the interactive `SessionBrowser` live in its own module long term, or should shared helpers migrate elsewhere as more TUI features arrive?
+- How do we want to verify both dependency setups (with/without `[browser]`) before release, and are the docs clear on that workflow?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,15 @@
 # Roadmap & Ideas
 
 ## Future Improvements
-- Explore a navigable session browser (arrow-key navigation, search filters).
-- Add automated tests covering message extraction, especially nested `response_item` payloads.
+- Interactive session browser (arrow-key navigation, search filters).
 - Selection using pressing numbers, writing particular multi-digits IDs
-- additional details
+- additional details (maybe including first few messages iot give use a hint?)
   - when selection using arrows
   - keyboard shortcut / menu
-- Find and summarize the relevant previous sessions (based on cwd)?
+- Find (and summarize) the relevant previous sessions (based on cwd)?
+
+- Add automated tests covering message extraction, especially nested `response_item` payloads.
+
 
 ## Nice-to-Haves
 - Publish the package to PyPI once ready to expose `pip install codex-summarize-session`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,6 @@
 # Roadmap & Ideas
 
 ## Future Improvements
-- Interactive session browser (arrow-key navigation, search filters).
 - Selection using pressing numbers, writing particular multi-digits IDs
 - additional details (maybe including first few messages iot give use a hint?)
   - when selection using arrows
@@ -11,6 +10,9 @@
 - Sessions filtering
   - recent
   - selected date span
+  - cwd based
+
+- Test various ways of install, [browser] version with dependency in particular.
 
 - Add automated tests covering message extraction, especially nested `response_item` payloads.
 
@@ -24,3 +26,6 @@
 ## Open Questions
 - Should the interactive `SessionBrowser` live in its own module long term, or should shared helpers migrate elsewhere as more TUI features arrive?
 - How do we want to verify both dependency setups (with/without `[browser]`) before release, and are the docs clear on that workflow?
+
+## Development Notes
+- Test both dependency setups when iterating on the browser: run once with `prompt_toolkit` installed (`python -m pip install .[browser]` or `pipx inject codex-summarize-session prompt_toolkit`) and again after uninstalling it (`python -m pip uninstall prompt_toolkit`) to ensure the CLI’s guidance for missing extras stays accurate.

--- a/codex_summarize_session/browser.py
+++ b/codex_summarize_session/browser.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Sequence, TYPE_CHECKING
+
+from prompt_toolkit.application import Application, run_in_terminal
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import HSplit, Layout, Window, ScrollOffsets
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.data_structures import Point
+from prompt_toolkit.layout.dimension import D
+from prompt_toolkit.styles import Style
+
+if TYPE_CHECKING:
+    from .cli import SessionEntry
+
+
+@dataclass
+class ExtractionRequest:
+    destination: Path
+    force: bool
+
+
+class SessionBrowser:
+    """Interactive browser backed by prompt_toolkit."""
+
+    PAGE_JUMP = 10
+
+    def __init__(self, entries: Sequence["SessionEntry"], sessions_dir: Path) -> None:
+        self.entries = list(entries)
+        self.sessions_dir = sessions_dir
+        self.selected_index = 0
+        session_count = len(self.entries)
+        noun = "session" if session_count == 1 else "sessions"
+        self.status: str = f"{session_count} {noun} under {self.sessions_dir}"
+        self._app: Optional[Application] = None
+        self._body_window: Optional[Window] = None
+
+    # ---- Layout helpers -------------------------------------------------
+    def _entry_fragments(self) -> list[tuple[str, str]]:
+        from .cli import format_session_entry_lines
+
+        lines = format_session_entry_lines(self.entries)
+        fragments: list[tuple[str, str]] = []
+        for idx, line in enumerate(lines):
+            style = "class:session-list.selected" if idx == self.selected_index else "class:session-list"
+            fragments.append((style, line))
+            if idx != len(lines) - 1:
+                fragments.append(("", "\n"))
+        return fragments
+
+    def _instructions_fragment(self) -> list[tuple[str, str]]:
+        text = "Up/Down navigate | PgUp/PgDn jump | Home/End | Enter extract | q quit"
+        return [("class:instructions", text)]
+
+    def _status_fragment(self) -> list[tuple[str, str]]:
+        return [("class:status", self.status)]
+
+    # ---- Key bindings ---------------------------------------------------
+    def _build_key_bindings(self) -> KeyBindings:
+        kb = KeyBindings()
+
+        @kb.add("up")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            self._move_selection(-1)
+
+        @kb.add("down")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            self._move_selection(1)
+
+        @kb.add("pageup")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            self._move_selection(-self.PAGE_JUMP)
+
+        @kb.add("pagedown")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            self._move_selection(self.PAGE_JUMP)
+
+        @kb.add("home")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            self._set_selection(0)
+
+        @kb.add("end")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            if self.entries:
+                self._set_selection(len(self.entries) - 1)
+
+        @kb.add("enter")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            self._handle_extract()
+
+        @kb.add("q")
+        @kb.add("Q")
+        @kb.add("escape")
+        @kb.add("c-c")
+        def _(event) -> None:  # pragma: no cover - interactive behaviour
+            event.app.exit(result=0)
+
+        return kb
+
+    # ---- Selection helpers ----------------------------------------------
+    def _move_selection(self, delta: int) -> None:
+        if not self.entries:
+            return
+        new_index = max(0, min(len(self.entries) - 1, self.selected_index + delta))
+        self._set_selection(new_index)
+
+    def _set_selection(self, index: int) -> None:
+        if not self.entries:
+            return
+        if index == self.selected_index:
+            return
+        self.selected_index = index
+        if self._app is not None:
+            self._app.invalidate()
+
+    # ---- Extraction handling -------------------------------------------
+    def _handle_extract(self) -> None:
+        if not self.entries:
+            return
+        entry = self.entries[self.selected_index]
+
+        def task() -> None:
+            request = self._prompt_destination(entry)
+            if request is None:
+                self.status = "Extraction cancelled."
+                return
+            from .cli import extract_messages
+
+            try:
+                count = extract_messages(
+                    input_path=entry.path,
+                    out=request.destination,
+                    out_dir=None,
+                    force=request.force,
+                    to_stdout=False,
+                )
+            except FileExistsError:
+                self.status = f"Refused to overwrite existing file: {request.destination}"
+            except OSError as exc:
+                self.status = f"Failed to write {request.destination}: {exc}"
+            else:
+                self.status = f"Wrote {count} messages -> {request.destination}"
+
+        run_in_terminal(task)
+        if self._app is not None:
+            self._app.invalidate()
+
+    def _prompt_destination(self, entry: "SessionEntry") -> Optional[ExtractionRequest]:
+        default_name = entry.path.with_suffix("").name + ".messages.jsonl"
+        default_path = Path.cwd() / default_name
+        current_default = default_path
+
+        while True:
+            try:
+                response = input(f"Destination path [{current_default}]: ")
+            except (KeyboardInterrupt, EOFError):
+                return None
+
+            text = response.strip()
+            if not text:
+                text = str(current_default)
+            dest = Path(text).expanduser()
+            if dest.is_dir():
+                dest = dest / default_name
+
+            if dest.exists():
+                try:
+                    confirm = input(f"{dest} exists. Overwrite? [y/N]: ")
+                except (KeyboardInterrupt, EOFError):
+                    return None
+                if confirm.strip().lower() in {"y", "yes"}:
+                    return ExtractionRequest(destination=dest, force=True)
+                current_default = dest
+                continue
+
+            return ExtractionRequest(destination=dest, force=False)
+
+    # ---- Public API -----------------------------------------------------
+    def run(self) -> int:
+        body_control = FormattedTextControl(
+            self._entry_fragments,
+            focusable=True,
+            get_cursor_position=lambda: Point(0, self.selected_index),
+        )
+        self._body_window = Window(
+            content=body_control,
+            height=D(min=3),
+            wrap_lines=False,
+            always_hide_cursor=True,
+            scroll_offsets=ScrollOffsets(top=2, bottom=2),
+        )
+        instructions_window = Window(
+            content=FormattedTextControl(self._instructions_fragment),
+            height=1,
+            always_hide_cursor=True,
+        )
+        status_window = Window(
+            content=FormattedTextControl(self._status_fragment),
+            height=1,
+            always_hide_cursor=True,
+        )
+
+        layout = Layout(
+            HSplit(
+                [
+                    self._body_window,
+                    Window(height=1, char="-", always_hide_cursor=True),
+                    instructions_window,
+                    status_window,
+                ]
+            )
+        )
+
+        style = Style.from_dict(
+            {
+                "session-list": "",
+                "session-list.selected": "reverse",
+                "instructions": "fg:#888888",
+                "status": "fg:#000000 bg:#e5e5e5",
+            }
+        )
+
+        self._app = Application(
+            layout=layout,
+            key_bindings=self._build_key_bindings(),
+            style=style,
+            full_screen=True,
+        )
+        result = self._app.run()
+        return 0 if result is None else result
+
+
+def browse_sessions(entries: Sequence["SessionEntry"], sessions_dir: Path) -> int:
+    browser = SessionBrowser(entries=entries, sessions_dir=sessions_dir)
+    return browser.run()

--- a/codex_summarize_session/cli.py
+++ b/codex_summarize_session/cli.py
@@ -297,7 +297,8 @@ def main(argv: Optional[list[str]] = None) -> int:
             if exc.name == "prompt_toolkit":
                 parser.error(
                     "Interactive browsing requires optional dependency 'prompt_toolkit'. "
-                    "Install with `pip install codex-summarize-session[browser]`."
+                    "Install it from the repo with `python -m pip install .[browser]` "
+                    "(or `pipx inject codex-summarize-session prompt_toolkit`)."
                 )
             raise
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ classifiers = [
 
 [project.scripts]
 codex-summarize-session = "codex_summarize_session.cli:main"
+
+[project.optional-dependencies]
+browser = [
+  "prompt_toolkit>=3.0,<4"
+]


### PR DESCRIPTION
## Summary
  - track the interactive session browser work behind a draft PR
  - outline the UX goals (arrow navigation, numeric selection, preview details)
  
##Implementation Plan (Draft)

  - Refactor shared session-loading/display helpers in codex_summarize_session/cli.py into functions that both list and browse can call.
  - Add prompt_toolkit as an optional dependency (document in README, note it in pyproject.toml extras or base deps).
  - Create browse command:
      - Render the session list with highlighting, reuse existing formatting.
      - Handle arrow up/down, page up/down, home/end.
      - On Enter, prompt for destination path (pre-filled) and call existing extract code.
      - Provide escape/q to quit without action.
  - Structure state so future additions (numeric jump, detail preview pane) are straightforward—e.g., store selections and a sidebar rendering hook even if the first version only shows the main list.
  - Update CLI help, README usage, and queue a CHANGELOG.md entry before marking the PR ready.
  - Validation: run list, extract commands today; add a manual walkthrough of browse selecting a sample session; capture screenshot/text snippet for the PR.

  ## Validation Plan
  - [x] run `python -m codex_summarize_session.cli list --limit 5`
  - [x] run `python -m codex_summarize_session.cli extract <session.jsonl> --stdout`
  - [x] add interactive browser smoke run once implemented

  ## Checklist
  - [X] implementation plan documented
  - [x] dependencies decided and added if needed
  - [x] changelog updated before marking ready